### PR TITLE
BZ-34908: build: specifykotlin lang target in blaze module

### DIFF
--- a/blaze/build.gradle.kts
+++ b/blaze/build.gradle.kts
@@ -9,7 +9,7 @@ android {
   compileSdk = 34
 
   defaultConfig {
-    minSdk = 24
+    minSdk = 21
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles("consumer-rules.pro")
@@ -27,6 +27,7 @@ android {
   }
   kotlinOptions {
     jvmTarget = "1.8"
+    languageVersion = "1.8"
   }
 }
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,12 +1,2 @@
 jdk:
   - openjdk17
-
-env:
-  kotlin_version: '1.8.0'
-
-install:
-  - ./gradlew build -Pkotlin_version=$kotlin_version
-
-build:
-  - ./gradlew :blaze:build
-  - ./gradlew :blaze:assembleRelease


### PR DESCRIPTION
- specified language target in build.gradle for blaze module
- reverted jitpack file changes for forcing 1.8.0 kotlin build steps