### PR TITLE
BZ-42472: feat: Implement UPI payment redirect handling in BlazeWebView

### DIFF
--- a/blaze/src/main/java/in/breeze/blaze/BlazeConstants.kt
+++ b/blaze/src/main/java/in/breeze/blaze/BlazeConstants.kt
@@ -1,0 +1,8 @@
+package `in`.breeze.blaze
+
+internal object BlazeConstants {
+    val UPI_SCHEMES = setOf(
+        "upi", "phonepe", "tez", "gpay", "paytm", "paytmmp", "bhim", 
+        "amazonpay", "mobikwik", "freecharge", "credpay"
+    )
+}

--- a/blaze/src/main/java/in/breeze/blaze/BlazeUtils.kt
+++ b/blaze/src/main/java/in/breeze/blaze/BlazeUtils.kt
@@ -1,5 +1,6 @@
 package `in`.breeze.blaze
 
+import android.net.Uri
 import org.json.JSONObject
 
 fun safeParseJson(jsonString: String): JSONObject {
@@ -17,4 +18,20 @@ fun getBaseUrl(payload: JSONObject): String {
   } else {
     "https://app.breeze.in"
   }
+}
+
+fun isUPIIntentUri(uri: Uri): Boolean {
+    val scheme = uri.scheme?.lowercase() ?: return false
+    val queryParams = uri.queryParameterNames.associateBy(
+        keySelector = { name -> name.lowercase() },
+        valueTransform = { name -> uri.getQueryParameter(name).orEmpty() }
+    )
+
+    val hasPayeeAddress = queryParams["pa"]?.isNotBlank() == true
+    val hasPayeeName = queryParams["pn"]?.isNotBlank() == true
+    val hasCurrency = queryParams["cu"]?.isNotBlank() == true
+    val hasAmount = queryParams["am"]?.isNotBlank() == true
+    val isKnownScheme = scheme in BlazeConstants.UPI_SCHEMES
+
+    return hasPayeeAddress && hasPayeeName && hasCurrency && hasAmount && isKnownScheme
 }

--- a/blaze/src/main/java/in/breeze/blaze/BlazeWebView.kt
+++ b/blaze/src/main/java/in/breeze/blaze/BlazeWebView.kt
@@ -10,14 +10,17 @@ import android.net.Uri
 import android.util.Log
 import android.view.ViewGroup
 import android.webkit.JavascriptInterface
+import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
+import androidx.core.net.toUri
 import org.json.JSONArray
 import org.json.JSONObject
 import java.lang.ref.WeakReference
 import java.util.Collections
+import androidx.core.content.edit
 
 
 internal class BlazeWebView @SuppressLint(
@@ -37,11 +40,32 @@ internal class BlazeWebView @SuppressLint(
   private val sharedPreferences: SharedPreferences
   private val baseUrl: String = getBaseUrl(initiatePayload)
 
+  private val blazeWebViewClient = object : WebViewClient() {
+
+    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+        val url = request?.url
+        if (url != null && isUPIIntentUri(url)) {
+            openApp(url.toString())
+            return true
+        }
+        return false
+    }
+
+    @Deprecated("Required for API < 24 compatibility")
+    override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
+        if (url != null && isUPIIntentUri(url.toUri())) {
+            openApp(url)
+            return true
+        }
+        return false
+    }
+  }
+
   init {
     this.webView.settings.javaScriptEnabled = true
     this.webView.settings.cacheMode = WebSettings.LOAD_DEFAULT
     this.webView.settings.domStorageEnabled = true
-    this.webView.webViewClient = WebViewClient()
+    this.webView.webViewClient = blazeWebViewClient
     this.webView.addJavascriptInterface(this, "Native")
     this.webView.loadUrl(baseUrl)
     this.sendEvent("initiate", this.initiatePayload)
@@ -193,9 +217,9 @@ internal class BlazeWebView @SuppressLint(
 
   private fun saveToStorage(key: String, value: String): Boolean {
     try {
-      val editor = sharedPreferences.edit()
-      editor.putString(key, value)
-      editor.apply()
+        sharedPreferences.edit() {
+            putString(key, value)
+        }
       return true
     } catch (e: Exception) {
       Log.e("BlazeSDK: Failure: ", e.message.toString())
@@ -216,7 +240,7 @@ internal class BlazeWebView @SuppressLint(
     intentUri: String
   ): String {
     try {
-      val intent = Intent(Intent.ACTION_VIEW, Uri.parse(intentUri))
+      val intent = Intent(Intent.ACTION_VIEW, intentUri.toUri())
       contextRef.get()?.startActivityForResult(intent, 0)
       return "Successfully triggered intent"
     } catch (e: Exception) {
@@ -230,7 +254,7 @@ internal class BlazeWebView @SuppressLint(
 
     if (pm !== null) {
       val upiApps = Intent()
-      upiApps.setData(Uri.parse(payload))
+      upiApps.setData(payload.toUri())
       val launchables: List<ResolveInfo> = pm.queryIntentActivities(upiApps, 0)
       Collections.sort(launchables, ResolveInfo.DisplayNameComparator(pm))
       for (resolveInfo in launchables) {


### PR DESCRIPTION
## Jira Ticket
refer [this](https://juspay.atlassian.net/browse/BZ-42472)

## Why?

- Enable seamless UPI payment experience for Android users by automatically redirecting UPI payment URLs to their respective payment apps  
- Prevent UPI payment links from loading within the WebView, which can cause payment failures or poor user experience  
- Support major Indian payment applications to ensure broad compatibility across the payment ecosystem  
- Improve payment conversion rates by providing native app experiences for UPI transactions  
- Achieve feature parity with iOS BlazeSDK UPI redirect implementation

## Solution

- Created BlazeConstants.kt with centralized UPI_SCHEMES constant
- Added isUPIIntentUri() function to BlazeUtils.kt with strict UPI parameter validation
- Refactored BlazeWebView to use inline blazeWebViewClient object instead of default WebViewClient
- Enhanced WebView URL interception with proper UPI scheme detection
- Modernized code with Kotlin extensions (toUri(), sharedPreferences.edit{})
- Added missing imports for WebResourceRequest and WebViewClient
- Improved type safety by replacing Uri.parse() calls with toUri() extension

## How to Test?

1. Load the BlazeSDK integrated app on a test device (physical device recommended)
2. Navigate to a payment method that offers UPI payment options (e.g., Simpl Pay-in-3)
3. Complete the login process for the payment service
4. In the payment flow, select and open a UPI payment method (e.g., GPay)
5. Verify that the external UPI app opens successfully (indicating UPI redirect is working)
6. Test with other available UPI payment options in the flow
7. Ensure the payment process completes successfully in the external app
8. Verify that non-UPI navigation within the WebView continues to work normally

## Dev Proof
https://drive.google.com/file/d/17-zwclCaW2AKhvcbDyMlk9bimZxrrKDK/view?usp=sharing

## Priority
High
